### PR TITLE
Fix "wrong-type-argument" and case sensitivity

### DIFF
--- a/code-stats.el
+++ b/code-stats.el
@@ -752,7 +752,8 @@
   (push pair code-stats-languages-by-extension))
 
 (defun code-stats-get-language ()
-  (or (cdr (assoc (file-name-extension buffer-file-name) code-stats-languages-by-extension #'string-equal))
+  (or (if (buffer-file-name)
+          (cdr (assoc-string (file-name-extension buffer-file-name) code-stats-languages-by-extension t)))
       (alist-get major-mode code-stats-languages-by-mode)
       (if (stringp mode-name)
           mode-name


### PR DESCRIPTION
In some buffers where there is no file, such as `*scratch*`, "wrong-type-argument
stringp nil" is fired back and prevents the buffer from being killed or closing
Emacs. This is because `buffer-file-name` returns nil, and `file-name-extension`
does not like it thereby throwing a wrench in the works.

Additionally, some files may have different capitalization for their extensions,
such as ".R" (uppercase is recommend by some) for R language. Because of this,
the previous `assoc` statement would erroneously return nil instead of `(r ."R")`,
and continue on to the backup case where it uses the mode name for the language.
Switching to `assoc-string` and enabling case folding eliminates the issue
allowing the return of the expected language no matter the casing of the
extension string.