### PR TITLE
Remove excess colon in time string

### DIFF
--- a/code-stats.el
+++ b/code-stats.el
@@ -788,7 +788,7 @@
 (defun code-stats-build-pulse ()
   (let ((xps (code-stats-collect-xps)))
     (when xps
-      `((coded_at . ,(format-time-string "%FT%T%:z"))
+      `((coded_at . ,(format-time-string "%FT%T%z"))
         (xps . [,@(cl-loop for (language . xp) in xps
                            collect `((language . ,language)
                                      (xp . ,xp)))])))))


### PR DESCRIPTION
Recently, Code Stats now seems to dislike the time format. A 401 error is
returned, and the XPs are refused.

Removing the colon resolves the issue.